### PR TITLE
fikset feil i mobil-versjon, i om-foreldrepenger er innformasjonsfane…

### DIFF
--- a/src/app/intl/nb_NO.json
+++ b/src/app/intl/nb_NO.json
@@ -136,7 +136,12 @@
     "om_foreldrepenger.nye_regler.før_beskrivelse": "Av den totale foreldrepengeperioden er 10 uker satt av til hver av foreldrene (kvoten). Får dere flere barn samtidig, får dere fem eller syv uker ekstra for hvert barn mer enn ett.",
     "om_foreldrepenger.nye_regler.etter": "etter 1. juli 2018",
     "om_foreldrepenger.nye_regler.etter_beskrivelse": "Av den totale foreldrepengeperioden er 15 uker satt av til hver av foreldrene (kvoten). Får dere to barn samtidig, får dere 17 eller 21 uker ekstra. Får dere tre eller flere barn, får dere 46 eller 56 uker ekstra.",
-    
+
+    "om_foreldrepenger.menHvaHvis.ferie": "ta ut ferie",
+    "om_foreldrepenger.menHvaHvis.jobb_i_periode": "jobbe i perioden",
+    "om_foreldrepenger.menHvaHvis.blirSyk": "noen blir syke",
+    "om_foreldrepenger.menHvaHvis.hjemmeSamtidig": "hjemme samtidig",
+
     "om_foreldrepenger.jobbe.tittel": "Jobbe i perioden",
     "om_foreldrepenger.jobbe.heltidsjobb": "Slik går du frem ved heltidsjobb",
     "om_foreldrepenger.jobbe.deltidsjobb": "Slik går du frem når du jobber delvis",

--- a/src/app/pages/om-foreldrepenger/hva-er-foreldrepenger/informasjons-faner/informasjonsfaner.less
+++ b/src/app/pages/om-foreldrepenger/hva-er-foreldrepenger/informasjons-faner/informasjonsfaner.less
@@ -1,4 +1,4 @@
-@import '../../../../styles/variables.less';
+@import '../../../../styles/index.less';
 
 .informasjonsfaner {
     margin: 0 -1rem;
@@ -55,11 +55,17 @@
         border-top: solid 0.5px transparent;
     }
 
+    .nav-frontend-tabs__tab-inner {
+        padding-left: 0;
+        padding-right: 0;
+    }
+
     .InformasjonsfanerBody {
         background-color: #fbfbfb;
         padding: 2rem;
 
         &__header {
+            display: -webkit-flex;
             display: flex;
             flex-direction: row;
             margin-top: 20px;
@@ -67,6 +73,7 @@
         }
 
         &__tid {
+            display: -webkit-flex;
             display: flex;
             flex-direction: column;
             font-weight: 900;
@@ -76,6 +83,7 @@
         }
 
         &__Icon {
+            display: -webkit-flex;
             display: flex;
             flex-direction: column;
             align-items: center;
@@ -116,6 +124,15 @@
 
     .nav-frontend-tabs {
         border-bottom: none;
+
+        &__tab-outer,
+        &__tab-label {
+            overflow: hidden;
+        }
+
+        .fanelabel__label {
+            .containText();
+        }
     }
 
     @media (min-width: @mobile-breakpoint) {
@@ -123,6 +140,11 @@
 
         &__header {
             margin-top: 2rem;
+        }
+
+        .nav-frontend-tabs__tab-inner {
+            padding-left: 1rem;
+            padding-right: 1rem;
         }
     }
 }

--- a/src/app/pages/om-foreldrepenger/hva-er-foreldrepenger/menHvaHvis/MenHvaHvis.tsx
+++ b/src/app/pages/om-foreldrepenger/hva-er-foreldrepenger/menHvaHvis/MenHvaHvis.tsx
@@ -43,7 +43,7 @@ class MenHvaHvis extends React.Component<Props> {
     updateWindowSize = () => {
         if (window.innerWidth < 799) {
             this.setState({
-                svgSize: '80px'
+                svgSize: '70px'
             });
         } else if (window.innerWidth >= 800) {
             this.setState({
@@ -63,25 +63,33 @@ class MenHvaHvis extends React.Component<Props> {
             <div className={cls.element('body')}>
                 <WithLink
                     style={{ height: this.state.svgSize, width: this.state.svgSize }}
-                    url={'#ta-ut-ferie'}>
+                    url={'#ta-ut-ferie'}
+                    noStyling={true}
+                    ariaLabel={getTranslation('om_foreldrepenger.menHvaHvis.ferie')}>
                     <NoenVilPaFerie size={this.state.svgSize} />
                 </WithLink>
 
                 <WithLink
                     style={{ height: this.state.svgSize, width: this.state.svgSize }}
-                    url={'#jobbe-i-perioden'}>
+                    url={'#jobbe-i-perioden'}
+                    noStyling={true}
+                    ariaLabel={getTranslation('om_foreldrepenger.menHvaHvis.jobb_i_periode')}>
                     <JegVilJobbe size={this.state.svgSize} />
                 </WithLink>
 
                 <WithLink
                     style={{ height: this.state.svgSize, width: this.state.svgSize }}
-                    url={'#noen-blir-syke'}>
+                    url={'#noen-blir-syke'}
+                    noStyling={true}
+                    ariaLabel={getTranslation('om_foreldrepenger.menHvaHvis.blirSyk')}>
                     <EnAvOssBlirSyk size={this.state.svgSize} />
                 </WithLink>
 
                 <WithLink
                     style={{ height: this.state.svgSize, width: this.state.svgSize }}
-                    url={'#hjemme-samtidig'}>
+                    url={'#hjemme-samtidig'}
+                    noStyling={true}
+                    ariaLabel={getTranslation('om_foreldrepenger.menHvaHvis.hjemmeSamtidig')}>
                     <HjemmeSamtidig size={this.state.svgSize} />
                 </WithLink>
             </div>

--- a/src/app/utils/withLink.less
+++ b/src/app/utils/withLink.less
@@ -15,3 +15,7 @@
         }
     }
 }
+
+.anchorLink {
+    cursor: pointer;
+}

--- a/src/app/utils/withLink.tsx
+++ b/src/app/utils/withLink.tsx
@@ -30,6 +30,7 @@ interface Props {
     noStyling?: boolean;
     className?: string;
     style?: any;
+    ariaLabel?: string;
     children: ReactNode;
 }
 
@@ -51,6 +52,7 @@ export class WithLink extends React.Component<Props> {
             noStyling,
             className,
             style,
+            ariaLabel,
             children
         } = this.props;
 
@@ -82,15 +84,28 @@ export class WithLink extends React.Component<Props> {
                 </Lenke>
             );
         } else if (url.charAt(0) === '#') {
-            return (
-                <Lenke
-                    className={className}
-                    style={style}
-                    onClick={(e) => this.goToSection(e, url)}
-                    href={url}>
-                    {children}
-                </Lenke>
-            );
+            if (noStyling) {
+                return (
+                    <span
+                        role="link"
+                        aria-label={ariaLabel}
+                        className={className + ' anchorLink'}
+                        style={style}
+                        onClick={(e) => this.goToSection(e, url)}>
+                        {children}
+                    </span>
+                );
+            } else {
+                return (
+                    <Lenke
+                        className={className + ' anchorLink'}
+                        style={style}
+                        onClick={(e) => this.goToSection(e, url)}
+                        href={url}>
+                        {children}
+                    </Lenke>
+                );
+            }
         } else {
             return (
                 <Link className={classnames(cls.className, className)} to={url}>


### PR DESCRIPTION
…r tilpasser 320px mobil bredde. anchor-lenkene er satt til å være span hvis noStyling ikke er true, som bør løse smooth-scrolling på iphone enheter. svg bredde ble også endret litt i menhvahvis for å tilpasse mobil-bredden.